### PR TITLE
Compatibility with CLion 182.3684.76.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.ver = [
-      kotlin: "1.1-M01",
+      kotlin: "1.2.51",
   ]
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${ver.kotlin}"
@@ -8,7 +8,7 @@ buildscript {
   repositories {
     jcenter()
     maven {
-      url "https://dl.bintray.com/kotlin/kotlin-eap-1.1"
+      url "https://dl.bintray.com/kotlin/kotlin-1.2.51"
     }
   }
 }
@@ -19,12 +19,12 @@ apply plugin: "kotlin"
 repositories {
   jcenter()
   maven {
-    url "https://dl.bintray.com/kotlin/kotlin-eap-1.1"
+    url "https://dl.bintray.com/kotlin/kotlin-1.2.51"
   }
 }
 
 group "io.ringle.ij"
-version "1.0.0"
+version "1.0.1"
 
 def clionPath = getCLionPath()
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jul 16 15:01:06 CDT 2016
+#Wed Jul 25 09:42:54 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip

--- a/src/main/kotlin/CMakeDocProvider.kt
+++ b/src/main/kotlin/CMakeDocProvider.kt
@@ -4,9 +4,10 @@ import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.psi.PsiElement
 import com.jetbrains.cidr.cpp.toolchains.CPPToolchains
-import com.jetbrains.cidr.cpp.cmake.psi.CMakeCommandName
-import com.jetbrains.cidr.cpp.cmake.psi.CMakeElement
-import com.jetbrains.cidr.cpp.cmake.psi.CMakeLiteral
+import com.jetbrains.cidr.cpp.toolchains.CPPEnvironment
+import com.jetbrains.cmake.psi.CMakeCommandName
+import com.jetbrains.cmake.psi.CMakeElement
+import com.jetbrains.cmake.psi.CMakeLiteral
 import org.asciidoc.intellij.AsciiDoc
 import org.jetbrains.rpc.LOG
 import java.io.IOException
@@ -23,8 +24,9 @@ class CMakeDocProvider : AbstractDocumentationProvider() {
   private val asciiDoc by lazy { AsciiDoc(createTempDir(), null, "clion-cmakedocs") }
 
   fun runCMake(vararg args: String): Process {
-    val cmake = CPPToolchains.getInstance().getToolchainByNameOrDefault(null)!!.cMake!!
-    LOG.info("CDP - Executing CMake: ${cmake.executablePath} ${args.joinToString(" ")}")
+    val cppEnvironment=CPPEnvironment(CPPToolchains.getInstance().getToolchainByNameOrDefault(null)!!)
+    val cmake = cppEnvironment.cMake
+    LOG.info("CDP - Executing CMake: ${cmake!!.executablePath} ${args.joinToString(" ")}")
     return ProcessBuilder(cmake.executablePath, *args).start()
   }
 

--- a/src/main/kotlin/CMakeDocProvider.kt
+++ b/src/main/kotlin/CMakeDocProvider.kt
@@ -3,7 +3,7 @@ import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.psi.PsiElement
-import com.jetbrains.cidr.cpp.CPPToolchains
+import com.jetbrains.cidr.cpp.toolchains.CPPToolchains
 import com.jetbrains.cidr.cpp.cmake.psi.CMakeCommandName
 import com.jetbrains.cidr.cpp.cmake.psi.CMakeElement
 import com.jetbrains.cidr.cpp.cmake.psi.CMakeLiteral
@@ -20,10 +20,10 @@ class CMakeDocProvider : AbstractDocumentationProvider() {
 
   private var variableList = ArrayList<String>()
 
-  private val asciiDoc by lazy { AsciiDoc(createTempDir()) }
+  private val asciiDoc by lazy { AsciiDoc(createTempDir(), null, "clion-cmakedocs") }
 
   fun runCMake(vararg args: String): Process {
-    val cmake = CPPToolchains.getInstance().cMake!!
+    val cmake = CPPToolchains.getInstance().getToolchainByNameOrDefault(null)!!.cMake!!
     LOG.info("CDP - Executing CMake: ${cmake.executablePath} ${args.joinToString(" ")}")
     return ProcessBuilder(cmake.executablePath, *args).start()
   }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
     ]]>
     </change-notes>
 
-    <idea-version since-build="141.0" />
+    <idea-version since-build="143.0" />
 
     <depends>com.intellij.modules.cidr.lang</depends>
     <depends>com.intellij.modules.clion</depends>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,18 +1,18 @@
 <idea-plugin url="https://github.com/eddieringle/clion-cmakedocs" version="2">
     <id>io.ringle.ij.cmakedocs</id>
     <name>CMake Docs</name>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
 
     <description><![CDATA[
       Adds Quick Documentation support for CMake commands, modules, properties, and variables to CLion.
     ]]></description>
 
     <change-notes><![CDATA[
-      Initial Release.
+      Added support for CLion 2018.2 (build 182.3684.76).
     ]]>
     </change-notes>
 
-    <idea-version since-build="143.0" />
+    <idea-version since-build="182" />
 
     <depends>com.intellij.modules.cidr.lang</depends>
     <depends>com.intellij.modules.clion</depends>


### PR DESCRIPTION
These commits adds compatibility with CLion 2018 (build 182.3684.76).